### PR TITLE
Fix locale-dependent validation issues

### DIFF
--- a/qt_parameters/inputs.py
+++ b/qt_parameters/inputs.py
@@ -297,7 +297,7 @@ class DoubleValidator(QtGui.QDoubleValidator):
             float(text)
         except ValueError:
             characters = '+-01234567890.'
-            text = [t for t in text if t in characters]
+            text = ''.join(t for t in text if t in characters)
 
         try:
             value = float(text)

--- a/qt_parameters/inputs.py
+++ b/qt_parameters/inputs.py
@@ -201,6 +201,9 @@ class FloatLineEdit(NumberLineEdit[float]):
 
     def _init_validator(self) -> None:
         self._validator = DoubleValidator()
+        # NOTE: Using QLocale.c() fixes validation issues in non-English locales that
+        # use comma decimal separators.
+        self._validator.setLocale(QtCore.QLocale.c())
         self._validator.setNotation(QtGui.QDoubleValidator.Notation.StandardNotation)
         self.setValidator(self._validator)
 


### PR DESCRIPTION
Force C locale in DoubleValidator to ensure consistent decimal separator behavior. This fixes validation issues in non-English locales where comma decimal separators caused State.Intermediate validation failures.

Fix DoubleValidator to join filtered characters into a string before parsing as float.