### PR TITLE
Use decimal precision for float slider

### DIFF
--- a/qt_parameters/inputs.py
+++ b/qt_parameters/inputs.py
@@ -361,6 +361,7 @@ class IntSlider(NumberSlider[int]):
 
     def _refresh_steps(self) -> None:
         """Refresh the slider page step and tick interval based on the range size."""
+
         range_size = self.maximum() - self.minimum()
         if range_size <= 10:
             tick_interval = 1
@@ -431,6 +432,7 @@ class FloatSlider(NumberSlider[float]):
 
     def set_decimals(self, decimals: int) -> None:
         """Set decimal precision for the slider."""
+
         self._decimals = decimals
         self._refresh_steps()
 
@@ -457,7 +459,11 @@ class FloatSlider(NumberSlider[float]):
         return float_value
 
     def _refresh_steps(self) -> None:
-        """Refresh the slider page step and tick interval based on the range size and decimal precision."""
+        """
+        Refresh the slider page step and tick interval based on the range size and
+        decimal precision.
+        """
+
         scale_factor = pow(10, self._decimals)
         int_min = int(self._minimum * scale_factor)
         int_max = int(self._maximum * scale_factor)

--- a/qt_parameters/inputs.py
+++ b/qt_parameters/inputs.py
@@ -381,6 +381,7 @@ class FloatSlider(NumberSlider[float]):
 
         self._minimum = super().minimum()
         self._maximum = super().maximum()
+        self._decimals = 2
 
         self.setSingleStep(1)
         self.setPageStep(10)
@@ -417,6 +418,11 @@ class FloatSlider(NumberSlider[float]):
         self._refresh_steps()
         self.set_value(value)
 
+    def set_decimals(self, decimals: int) -> None:
+        """Set decimal precision for the slider."""
+        self._decimals = decimals
+        self._refresh_steps()
+
     def _int(self, value: float) -> int:
         """Return an int value in slider scale."""
 
@@ -442,9 +448,8 @@ class FloatSlider(NumberSlider[float]):
     def _refresh_steps(self) -> None:
         """Refresh the slider ticks and steps based on the minimum and maximum."""
 
-        # Find a value that brings the float range into an int range
-        # with step size locked to 1 and 10
-        step = pow(10, -(self._exponent() - 2))
+        # Scale step based on decimals
+        step = pow(10, max(2, self._decimals))
 
         self.blockSignals(True)
         self.setMinimum(int(self._minimum * step))

--- a/qt_parameters/widgets.py
+++ b/qt_parameters/widgets.py
@@ -206,7 +206,7 @@ class FloatParameter(IntParameter):
     _slider_max: float = 1
     _line_min: float | None = None
     _line_max: float | None = None
-    _decimals: int = 4
+    _decimals: int = 2
 
     def _init_ui(self) -> None:
         # line
@@ -219,6 +219,7 @@ class FloatParameter(IntParameter):
         # slider
         self.slider = FloatSlider()
         self.slider.set_maximum(self._slider_max)
+        self.slider.set_decimals(self._decimals)
         self.slider.value_changed.connect(self._slider_value_changed)
         # prevent any size changes when slider shows
         self.slider.setMaximumHeight(self.line.minimumSizeHint().height())
@@ -812,7 +813,7 @@ class MultiFloatParameter(MultiIntParameter):
     _line_max: float | None = None
     _slider_min: float = 0
     _slider_max: float = 1
-    _decimals: int = 4
+    _decimals: int = 2
 
     def _init_ui(self) -> None:
         # Lines

--- a/qt_parameters/widgets.py
+++ b/qt_parameters/widgets.py
@@ -234,6 +234,7 @@ class FloatParameter(IntParameter):
     def set_decimals(self, decimals: int) -> None:
         self._decimals = decimals
         self.line.set_decimals(decimals)
+        self.slider.set_decimals(decimals)
 
     def line_min(self) -> float:
         return super().line_min()
@@ -829,6 +830,7 @@ class MultiFloatParameter(MultiIntParameter):
         # Slider
         self.slider = FloatSlider()
         self.slider.set_maximum(self._slider_max)
+        self.slider.set_decimals(self._decimals)
         self.slider.value_changed.connect(self._slider_value_changed)
         # Prevent any size changes when slider shows
         line_height = self.lines[0].minimumSizeHint().height()
@@ -852,6 +854,7 @@ class MultiFloatParameter(MultiIntParameter):
         self._decimals = decimals
         for line in self.lines:
             line.set_decimals(decimals)
+        self.slider.set_decimals(decimals)
 
     def line_min(self) -> float:
         return super().line_min()


### PR DESCRIPTION
Fix slider precision mismatch by syncing decimals between line edit and slider steps. Change the default decimal precision from 4 to 2 in FloatSlider, FloatParameter, and MultiFloatParameter.

This makes the float sliders much more precise for use cases with more decimal places. By changing the default decimal precision to 2 for the float parameters, overly precise sliders are avoided if decimals are not set.