### PR TITLE
Fix IntLineEdit locale issue causing values ≥ 1000 to reset to 0

### DIFF
--- a/qt_parameters/inputs.py
+++ b/qt_parameters/inputs.py
@@ -35,6 +35,9 @@ class NumberLineEdit(QtWidgets.QLineEdit, Generic[N]):
 
     def _init_validator(self) -> None:
         self._validator = IntValidator()
+        # NOTE: Using QLocale.c() fixes validation issues in non-English locales that
+        # use period thousand separators.
+        self._validator.setLocale(QtCore.QLocale.c())
         self.setValidator(self._validator)
 
     def value(self) -> N:
@@ -190,13 +193,6 @@ class NumberLineEdit(QtWidgets.QLineEdit, Generic[N]):
 
 class IntLineEdit(NumberLineEdit[int]):
     value_changed = QtCore.Signal(int)
-
-    def _init_validator(self) -> None:
-        self._validator = IntValidator()
-        # NOTE: Using QLocale.c() fixes validation issues in non-English locales that
-        # use period thousand separators.
-        self._validator.setLocale(QtCore.QLocale.c())
-        self.setValidator(self._validator)
 
 
 class FloatLineEdit(NumberLineEdit[float]):

--- a/qt_parameters/inputs.py
+++ b/qt_parameters/inputs.py
@@ -191,6 +191,13 @@ class NumberLineEdit(QtWidgets.QLineEdit, Generic[N]):
 class IntLineEdit(NumberLineEdit[int]):
     value_changed = QtCore.Signal(int)
 
+    def _init_validator(self) -> None:
+        self._validator = IntValidator()
+        # NOTE: Using QLocale.c() fixes validation issues in non-English locales that
+        # use period thousand separators.
+        self._validator.setLocale(QtCore.QLocale.c())
+        self.setValidator(self._validator)
+
 
 class FloatLineEdit(NumberLineEdit[float]):
     value_changed = QtCore.Signal(float)


### PR DESCRIPTION
## Issue

On systems using a locale with period thousand separators (e.g. German: 1.000), QIntValidator.fixup formats values ≥ 1000 with that separator. Since IntValidator.fixup does not strip periods, Python's int() then raises ValueError on the formatted string, and commit() falls back to 0.

## Fix
Override _init_validator in IntLineEdit to set QLocale.c() on the validator, matching the existing pattern in FloatLineEdit (introduced in #2 for the float case).